### PR TITLE
TEDEFO-980

### DIFF
--- a/modules/schema/pages/competition-results.adoc
+++ b/modules/schema/pages/competition-results.adoc
@@ -576,7 +576,7 @@ only),
 
 * Subcontracting terms,
 
-* Reference to the "Contracting Party" that submitted the
+* Reference to the "Tendering Party" that submitted the
 tender,
 
 * Reference to the Lot or Group of lots the tender is about


### PR DESCRIPTION
Changed
Reference to the "Contracting Party" that submitted the tender
To
Reference to the "Tendering Party" that submitted the tender