### PR TITLE
TEDEFO-2295 change in the section about 'Getting the element order right'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 /antora-playbook-local.yml
+.project

--- a/modules/guide/pages/xml-generation.adoc
+++ b/modules/guide/pages/xml-generation.adoc
@@ -134,7 +134,7 @@ TIP: Simply splitting the XPath string on `'/'` won't work. You can use regular 
 NOTE: We know that extracting the `steps` from an XPath is not rocket science and that you can do it yourself; but it would have been much easier for everyone, if we had provided this information pre-processed and ready for you inside `fields.json`. This is something we intend to do in a future release of the SDK. 
 
 === Getting the element order right
-Ideally we would like you to be able to generate the XML without ever needing to look at the XSD. For the moment however, there is a piece of necessary information that you can only find inside the XSD: the correct order of XML elements within their parent element. This is because the order of XML elements inside an `xsd:sequence` is significant.
-
-NOTE: We are aware that having to open the XSD just to lookup the order of XML elements is not very convenient. So we plan to add this in `fields.json` in a future release of the SDK.
+Ideally we would like you to be able to generate the XML without ever needing to look at the XSD. 
+For this reason we now provide the `xsdSequenceOrder` in the `fields.json`.
+One possible algorithm to use for sorting notice XML will be provided in the editor demo project, the previous algorithm was fully XSD sequence based.
 

--- a/modules/guide/pages/xml-generation.adoc
+++ b/modules/guide/pages/xml-generation.adoc
@@ -135,7 +135,7 @@ NOTE: We know that extracting the `steps` from an XPath is not rocket science an
 
 === Getting the XML element order right
 In `fields/fields.json` a property called `xsdSequenceOrder` is available for every field that is not pointing to an XML attribute and node that is not `ND-Root`.
-You can read more about it in the link:https://docs.ted.europa.eu/eforms/latest/fields/index.html[fields documentation].
+You can read more about it in the xref:fields:index.adoc[field metadata documentation].
 
 Simplified example field from the `fields.json`:
 

--- a/modules/guide/pages/xml-generation.adoc
+++ b/modules/guide/pages/xml-generation.adoc
@@ -133,8 +133,34 @@ TIP: Simply splitting the XPath string on `'/'` won't work. You can use regular 
 
 NOTE: We know that extracting the `steps` from an XPath is not rocket science and that you can do it yourself; but it would have been much easier for everyone, if we had provided this information pre-processed and ready for you inside `fields.json`. This is something we intend to do in a future release of the SDK. 
 
-=== Getting the element order right
-Ideally we would like you to be able to generate the XML without ever needing to look at the XSD. 
-For this reason we now provide the `xsdSequenceOrder` in the `fields.json`.
-One possible algorithm to use for sorting notice XML will be provided in the editor demo project, the previous algorithm was fully XSD sequence based.
+=== Getting the XML element order right
+In `fields/fields.json` a property called `xsdSequenceOrder` is available for every field that is not pointing to an XML attribute and node that is not `ND-Root`.
+You can read more about it in the link:https://docs.ted.europa.eu/eforms/latest/fields/index.html[fields documentation].
 
+Simplified example field from the `fields.json`:
+
+....
+{
+    "id" : "BT-13713-LotResult",
+    "parentNodeId" : "ND-LotResult",
+    "xpathRelative" : "efac:TenderLot/cbc:ID",
+    "xsdSequenceOrder" : [ { "efac:TenderLot" : 16 }, { "cbc:ID" : 1 } ]
+....
+
+Here the `xpathRelative` has two parts, for each part we want the order of the element relative to the other child under the same parent element:
+
+* `efac:TenderLot` is at child order number 16 under the element of parent node `ND-LotResult`, meaning potentially 15 elements could be in front
+* `cbc:ID` has child order number 1 under `efac:TenderLot`, meaning if it is present it must be the first child
+
+==== Order of repeating elements
+If a field or node is repeatable, then the repeated elements should be next to each other in the XML.
+The original order of the repeating items should be preserved.
+
+==== Order of attributes
+Even if XML is not imposing an attribute order, they could be sorted in alphabetic order.
+This can avoid to have variations each time the same XML is generated.
+
+==== Demo sorting algorithm
+In general we recommend to first build the entire notice XML and do the sorting at the end.
+An algorithm for sorting a notice XML is provided in the link:https://github.com/OP-TED/eforms-notice-editor[editor demo].
+Note that before SDK 1.8 the XML sorting algorithm in the editor demo relied only information found the schemas (XSD) of the SDK.


### PR DESCRIPTION
I am sure we need another text for this topic, but not sure about the text to put.
The work about sorting using xsdSequenceOrder in the editor demo looks OK for 1.8 and should work well for notices produced by the form editor. Not sure it is currently working better than the fully XSD based code for every possible scenario as it is difficult to test this.