### PR TITLE
fields: Explain the various "OP*-*" fields

### DIFF
--- a/modules/fields/pages/index.adoc
+++ b/modules/fields/pages/index.adoc
@@ -40,7 +40,7 @@ For example, "OPT-300-Procedure-Buyer" corresponds to the reference to the ident
 +
 For example, "OPP-012-notice" corresponds to the date of publication of the notice in the Official Journal of the EU.
 
-`OPA`:: "Alias" field, needed to get the numerical value of a regular field that also has a unit (duration, monetary amount, etc.). Those fields can be ignored when generating the XML notice, as the regular field has the numerical value and unit.
+`OPA`:: "Alias" field, needed to separately identify the numerical value and the unit of a regular field that has both (duration, monetary amount, etc.). Those fields can be ignored when generating the XML notice, as the regular field has the numerical value and unit.
 +
 For example, "OPA-36-Lot-Number" corresponds to the numerical value of "BT-36-Lot", which is the estimated duration of the contract.
 

--- a/modules/fields/pages/index.adoc
+++ b/modules/fields/pages/index.adoc
@@ -40,7 +40,7 @@ For example, "OPT-300-Procedure-Buyer" corresponds to the reference to the ident
 +
 For example, "OPP-012-notice" corresponds to the date of publication of the notice in the Official Journal of the EU.
 
-`OPA`:: "Alias" field, needed to separately identify the numerical value and the unit of a regular field that has both (duration, monetary amount, etc.). Those fields can be ignored when generating the XML notice, as the regular field has the numerical value and unit.
+`OPA`:: "Alias" field, needed to get the numerical value of a regular field that also has a unit (duration, monetary amount, etc.). Those fields can be ignored when generating the XML notice, as the regular field has the numerical value and unit.
 +
 For example, "OPA-36-Lot-Number" corresponds to the numerical value of "BT-36-Lot", which is the estimated duration of the contract.
 

--- a/modules/fields/pages/index.adoc
+++ b/modules/fields/pages/index.adoc
@@ -24,7 +24,26 @@ For the example above, the fields defined for BT-27 are:
 * BT-27-Procedure : estimated value of the procedure
 * BT-27-Lot : estimated value of a lot
 * BT-27-Part : estimated value of a part
-* BT-27-LotsGroup : estimated value of a group of lots 
+* BT-27-LotsGroup : estimated value of a group of lots
+
+=== Fields other than "BT-*"
+
+In addition to the above, some fields do not correspond to a business term in the eForms Regulation. They are needed because of the specific structure of the XML notices, or to fulfil a specific requirement.
+
+The identifiers for those fields all start with "OP" (the abbreviation for "Publications Office"), followed by a letter indicating the nature of the field:
+
+`OPT`:: Technical field, needed because of a technical design choice or constraint.
++
+For example, "OPT-300-Procedure-Buyer" corresponds to the reference to the identifier of the organisation for the buyer.
+
+`OPP`:: "Production" field, needed for the production and publication processes, or for forms that are not defined in the eForms Regulation.
++
+For example, "OPP-012-notice" corresponds to the date of publication of the notice in the Official Journal of the EU.
+
+`OPA`:: "Alias" field, needed to get the numerical value of a regular field that also has a unit (duration, monetary amount, etc.). Those fields can be ignored when generating the XML notice, as the regular field has the numerical value and unit.
++
+For example, "OPA-36-Lot-Number" corresponds to the numerical value of "BT-36-Lot", which is the estimated duration of the contract.
+
 
 [#field-repository]
 == The field repository

--- a/modules/schema/pages/notices-xml-structure.adoc
+++ b/modules/schema/pages/notices-xml-structure.adoc
@@ -97,16 +97,9 @@ Basing the development of the eForms schema on the UBL schema, as well as
 conferring many advantages, has also imposed some constraints. These 
 constraints have required the creation of a number of terms which were not 
 anticipated in the eForms Regulation; they do not have a true Business 
-justification. They have been assigned different abbreviations to distinguish 
-them from the BT terms defined in the eForms Regulation.
-
-Two abbreviations for these fields have been introduced: "OPP" and "OPT". "OP" 
-is the abbreviation for the Publications Office of the European Union as 
-defined above. "P" stands for Production; these fields are required for the 
-production processes, particularly for the non-standard forms (not defined in 
-the eForms Regulation) that also use the eForms schema. "T" stands for 
-Technical, these are required for some technical constraints and chosen 
-design options.
+justification. They have been assigned different abbreviations, starting with
+"OP" to distinguish them from the BT terms defined in the eForms Regulation
+(see xref:fields:index.adoc[] for more details).
 
 == Dates and Times
 


### PR DESCRIPTION
Also remove the paragraph about this in the "schema" module, and put a link to the updated field page instead.

This is only for 1.9.x, as "OPA-*" fields were used a bit differently in previous SDK versions.