### PR TITLE
Add new page for the content of the "schemas" folder

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -10,6 +10,7 @@ include::{page-component-version}@eforms:codelists:partial$nav.adoc[]
 include::{page-component-version}@eforms:notice-types:partial$nav.adoc[]
 include::{page-component-version}@eforms:viewer-templates:partial$nav.adoc[]
 include::{page-component-version}@eforms:translations:partial$nav.adoc[]
+include::{page-component-version}@eforms:schemas:partial$nav.adoc[]
 include::{page-component-version}@eforms:schematrons:partial$nav.adoc[]
 include::{page-component-version}@eforms:efx:partial$nav.adoc[]
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -29,6 +29,8 @@ How each notice type is structured.
 Reusable templates for visualising notices.
 * xref:translations:index.adoc[Translations] +
 Find out which translations are included in the SDK and learn how to use them.
+* xref:schemas:index.adoc[XML Schemas] +
+The XSD files that define the structure of XML notices.
 * xref:schematrons:index.adoc[Schematron] +
 The Schematron files used to validate XML notices.
 * xref:efx:index.adoc[eForms Expression Language] +

--- a/modules/schemas/pages/index.adoc
+++ b/modules/schemas/pages/index.adoc
@@ -11,19 +11,19 @@ The schema files are organised in 2 folders under `schemas`, following the same 
 * `maindoc`: schemas for the individual document types.
 * `common`: schemas in the common library, referenced and used from the document types defined in the `maindoc` folder.
 
-The entry point to validate an XML notices against the schema is a one of the files in the `maindoc` folder. The appropriate file can be selected based on the root element, namespace, or notice subtype of the XML notice, using the information provided in the xref:notice-types:index.adoc[`notice-types.json` file].
+The entry point to validate an XML notice against the schema is a one of the files in the `maindoc` folder. The appropriate file can be selected based on the root element, namespace, or notice subtype of the XML notice, using the information provided in the xref:notice-types:index.adoc[`notice-types.json` file].
 
 == Differences with UBL
 
 In order to meet some requirements specific to eForms, we have extended the UBL 2.3 standard, through the extension mechanism it provides, and also by creating an additional document type.
 
-This means that any valid eForms XML notice is also conforms to UBL 2.3.
+This means that any valid eForms XML notice also conforms to UBL 2.3.
 
-The files coming from the UBL standard (with names starting with `UBL` and `BDNDR`) have been left unmodified, with the exception of `UBL-ExtensionContentDataType-2.3.xsd`, which has been modified to reference only the eForms extension.
+The files taken from the UBL standard (with names starting with `UBL` and `BDNDR`) have been left unmodified, with the exception of `UBL-ExtensionContentDataType-2.3.xsd`, which has been modified to reference only the eForms extension.
 
-The XSD files that are part of the UBL standard but are not used in eForms are not included in the eForms SDK.
+The XSD files that are part of the UBL standard but not used in eForms are not included in the eForms SDK.
 
-The XSD files added for eForms have a name that starts with `EFORMS`:
+The XSD files added for eForms have names that start with `EFORMS`:
 
 `maindoc\EFORMS-BusinessRegistrationInformationNotice.xsd`::
 Specific document type for business registration notices (notice subtypes X01 and X02).

--- a/modules/schemas/pages/index.adoc
+++ b/modules/schemas/pages/index.adoc
@@ -1,0 +1,38 @@
+= XML Schema files
+
+== Introduction
+
+The structure of eForms XML notices is defined in a set of XML Schema Definition (XSD) files. The schemas are based on Pre-Award document types of the https://docs.oasis-open.org/ubl/UBL-2.3.html[UBL 2.3 standard].
+
+== Structure of schema files
+
+The schema files are organised in 2 folders under `schemas`, following the same structure used by UBL:
+
+* `maindoc`: schemas for the individual document types.
+* `common`: schemas in the common library, referenced and used from the document types defined in the `maindoc` folder.
+
+The entry point to validate an XML notices against the schema is a one of the files in the `maindoc` folder. The appropriate file can be selected based on the root element, namespace, or notice subtype of the XML notice, using the information provided in the xref:notice-types:index.adoc[`notice-types.json` file].
+
+== Differences with UBL
+
+In order to meet some requirements specific to eForms, we have extended the UBL 2.3 standard, through the extension mechanism it provides, and also by creating an additional document type.
+
+This means that any valid eForms XML notice is also conforms to UBL 2.3.
+
+The files coming from the UBL standard (with names starting with `UBL` and `BDNDR`) have been left unmodified, with the exception of `UBL-ExtensionContentDataType-2.3.xsd`, which has been modified to reference only the eForms extension.
+
+The XSD files that are part of the UBL standard but are not used in eForms are not included in the eForms SDK.
+
+The XSD files added for eForms have a name that starts with `EFORMS`:
+
+`maindoc\EFORMS-BusinessRegistrationInformationNotice.xsd`::
+Specific document type for business registration notices (notice subtypes X01 and X02).
+
+`common\EFORMS-ExtensionApex-2.3.xsd`::
+Definition of the eForms extension element.
+
+`common\EFORMS-ExtensionAggregateComponents-2.3.xsd`::
+Definition of specific aggregate components for the eForms extension.
+
+`common\EFORMS-ExtensionBasicComponents-2.3.xsd`::
+Definition of specific basic components for the eForms extension.

--- a/modules/schemas/partials/nav.adoc
+++ b/modules/schemas/partials/nav.adoc
@@ -1,0 +1,1 @@
+* xref:{page-component-version}@eforms:schemas:index.adoc[XML Schemas]


### PR DESCRIPTION
The added module is named `schemas`, which is a bit awkward with the existing `schema` module, but it is consistent with the other modules, named after the folder of the SDK they describe.