### PR TITLE
Allowing reference to a TEDXML notice using BT-1252 (Doc update TEDEFO-2853)

### DIFF
--- a/modules/schema/pages/identifiers.adoc
+++ b/modules/schema/pages/identifiers.adoc
@@ -131,7 +131,13 @@ planning notice |notice-id-ref |UUID-XX
 the previous planning notice Part | |PAR-XXXX
 
 |BT-1252 |Direct Award Justification Previous Procedure Identifier
-|Procedure Identifier (BT-04) | |UUID v4
+a|Procedure Identifier (BT-04), or
+
+TEDXML OJS Notice ID | a|
+
+UUID v4,
+ 
+XXXXXXXX-YYYY
 
 |BT-13713 |Result Lot Identifier |Points to the Lot (BT-137, LOT-XXXX)
 the result is about |Lot |LOT-XXXX

--- a/modules/schema/pages/procedure-lot-part-information.adoc
+++ b/modules/schema/pages/procedure-lot-part-information.adoc
@@ -3037,13 +3037,13 @@ justification is encoded with the "_ProcessReason_" element:
 ----
 
 [[directAwardSection]]
-=== Direct Award Justification (BT-135, BT-136, BT-1252) 
-
+==== Direct Award Justification (BT-135, BT-136, BT-1252) 
 When the Procedure Type is a Direct Award, then the justification is
 encoded with the "_cbc:ProcessReasonCode_" element. The
 "_cbc:ProcessReason_" element may be used to provide further information
 as text when required and "_cbc:Description_" may be used to refer to the previous
-procedure (using its UUID) that justified the Direct Award:
+procedure (using its UUID for an eForms notice) or to the Result or Change notice 
+(using its ojs-notice-id for a TEDXML notice) that justified the Direct Award:
 
 [source,xml]
 ----


### PR DESCRIPTION
BT-1252 now also allows for "ojs-notice-id" reference (rule updated with TEDEFO-2852), 