### PR TITLE
Add note on deprecation of version information in specific files (TEDEFO-2828)

### DIFF
--- a/modules/codelists/pages/index.adoc
+++ b/modules/codelists/pages/index.adoc
@@ -75,6 +75,10 @@ The file named `codelists.json` provides information on each codelist.
 <7> Description of the codelist.
 <8> Identifier of the label for the name of the codelist. The label is available in the xref:translations:index.adoc[translations] folder.
 
+NOTE: The properties `ublVersion`, `sdkVersion`, and `metadataDatabase` are deprecated.
+The values in those properties may not be updated if the file is not modified, for example in a patch version, so they might differ from the exact version of the SDK.
+You should use the version of the SDK package, or the content of the VERSION file in the top-level folder of the SDK.
+
 In eForms, codelists are referenced using their identifier. The identifier is 
 also indicated in the codelist Genericode files, in the "LongName" element
 which has no attributes:

--- a/modules/fields/pages/index.adoc
+++ b/modules/fields/pages/index.adoc
@@ -92,6 +92,10 @@ The field repository is mainly an array of fields, preceded by some version info
 <4> General structure of XML notices. See the xref:xml-structure.adoc[] page.
 <5> List of fields.
 
+NOTE: The properties `ublVersion`, `sdkVersion`, and `metadataDatabase` are deprecated.
+The values in those properties may not be updated if the file is not modified, for example in a patch version, so they might differ from the exact version of the SDK.
+You should use the version of the SDK package, or the content of the VERSION file in the top-level folder of the SDK.
+
 == Field properties
 
 The various characteristics of each field are indicated as properties of the JSON object that represents it.

--- a/modules/notice-types/pages/index.adoc
+++ b/modules/notice-types/pages/index.adoc
@@ -73,6 +73,10 @@ This file contains some metadata, followed by the list of notice subtypes, and t
 <18> Full URI of the additional namespace.
 <19> Location of the XSD file that contains the definition of the elements in the namespace, relative to the root of the SDK.
 
+NOTE: The properties `ublVersion`, `sdkVersion`, and `metadataDatabase` are deprecated.
+The values in those properties may not be updated if the file is not modified, for example in a patch version, so they might differ from the exact version of the SDK.
+You should use the version of the SDK package, or the content of the VERSION file in the top-level folder of the SDK.
+
 From the information visible in the example above, we can see that the notice subtype 1 has the document type `PIN`, so the root element in the XML is `PriorInformationNotice`.
 The definition of this root element is in the file indicated by the `schemaLocation` property.
 

--- a/modules/viewer-templates/pages/index.adoc
+++ b/modules/viewer-templates/pages/index.adoc
@@ -40,6 +40,11 @@ The file named `view-templates.json` provides information on each view template.
 <7> List of the notice subtypes that can be visualised with this view template.
 <8> Identifier of the label for the name of the view template. The label is available in the xref:translations:index.adoc[translations] folder.
 
+NOTE: The properties `ublVersion`, `sdkVersion`, and `metadataDatabase` are deprecated.
+The values in those properties may not be updated if the file is not modified, for example in a patch version, so they might differ from the exact version of the SDK.
+You should use the version of the SDK package, or the content of the VERSION file in the top-level folder of the SDK.
+
+
 For this version of the eForms SDK there is only one template available for every notice subtype. In addition, there is a `summary` template that can be used for any notice subtype, and, as the name implies, it generates a summarised view of the notice.
 
 == Template language syntax


### PR DESCRIPTION
When we describe the properties "ublVersion", "sdkVersion", or "metadataDatabase", add a note about their deprecation.

This is only for the 1.11.x branch, as we can't really announce a deprecation retroactively.