### PR TITLE
Update links to the TED website

### DIFF
--- a/modules/schema/pages/disclaimer.adoc
+++ b/modules/schema/pages/disclaimer.adoc
@@ -1,12 +1,7 @@
 = Disclaimer
 
-This document refers to the provisional version of the eForms schemas
+This document refers to the version of the eForms schemas
 published as part of the SDK {page-component-version}.
 
 The schemas and the documentation can still be subject to changes. They
 should therefore be considered as provisional.
-
-Further information, including Business Rules, will be provided in the
-near future. You may send questions and observations to the helpdesk via
-https://simap.ted.europa.eu/contact[https://simap.ted.europa.eu/contact]
-with the word "_eForms_" in the subject.

--- a/modules/schema/pages/other-resources.adoc
+++ b/modules/schema/pages/other-resources.adoc
@@ -11,8 +11,8 @@ https://github.com/eprocurementontology/eprocurementontology[https://github.com/
 https://github.com/eForms/eForms[https://github.com/eForms/eForms]
 
 * [[eFormSimap,W-04]] 
-eForms on SIMAP (communication channel to eSenders)
-https://simap.ted.europa.eu/en_GB/web/simap/eforms[https://simap.ted.europa.eu/en_GB/web/simap/eforms]
+eForms on the TED website
+https://ted.europa.eu/en/simap/eforms[https://ted.europa.eu/en/simap/eforms]
 
 * [[lawInsiderTenderingParty,W-05]] 
 Law Insider, Dictionary, Tendering Party definition

--- a/supplemental-ui/partials/header-content.hbs
+++ b/supplemental-ui/partials/header-content.hbs
@@ -12,7 +12,7 @@
   <div class="navbar-dropdown">
     <!-- <div class="navbar-item"><b>Publications Ofiice</b></div> -->
     <a class="navbar-item" href="https://github.com/OP-TED/eForms-SDK">eForms SDK on Github</a>
-    <a class="navbar-item" href="https://simap.ted.europa.eu/web/simap/eforms">eForms on SIMAP</a>
+    <a class="navbar-item" href="https://ted.europa.eu/en/simap/eforms">eForms on the TED website</a>
     <a class="navbar-item" href="https://github.com/eprocurementontology/eprocurementontology">eProcurement
       Ontology</a>
     <a class="navbar-item" href="https://github.com/espd/espd-edm">European Single Procurement Document</a>
@@ -26,7 +26,7 @@
   </div>
 </div>
 
-<a class="navbar-item" href="https://simap.ted.europa.eu/contact">Helpdesk</a>
+<a class="navbar-item" href="https://ted.europa.eu/en/contact">Helpdesk</a>
 
 <div class="navbar-item">
   <span class="control">


### PR DESCRIPTION
Use the URLs on the new website, and remove explicit mentions of "SIMAP", as it's not a separate website anymore.

This PR goes to 1.6.x, the oldest SDK version currently active, as we want the links to be updated there too.
I'll merge this into other versions afterwards.