### PR TITLE
Adding new Procedure Types for T01 and T02 Notice Subtypes (TEDEFO-3172)

### DIFF
--- a/modules/schema/pages/procedure-lot-part-information.adoc
+++ b/modules/schema/pages/procedure-lot-part-information.adoc
@@ -2666,6 +2666,7 @@ code; A: allowed code and procedure may additionally be accelerated) :
 |oth-single |-- |-- |-- |-- |-- |-- |X |X |-- 
 |oth-mult |-- |-- |-- |-- |-- |-- |X |X |-- 
 |comp-tend |-- |-- |-- |-- |-- |-- |-- |-- |-- 
+|exp-int-rail |-- |-- |-- |-- |-- |-- |-- |-- |-- 
 |===
 
 
@@ -2686,6 +2687,7 @@ code; A: allowed code and procedure may additionally be accelerated) :
 |oth-single |X |X |X |X |-- |-- |X |X |X |-- |X |X |-- |X |X 
 |oth-mult |X |X |X |X |-- |-- |X |X |X |-- |X |X |-- |X |X 
 |comp-tend |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- 
+|exp-int-rail |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- 
 |===
 
 
@@ -2706,6 +2708,7 @@ code; A: allowed code and procedure may additionally be accelerated) :
 |oth-single |X |X |X |X |X |X |X |-- |X |X |-- |X |X |-- |-- |-- 
 |oth-mult |X |X |X |X |X |X |X |-- |X |X |-- |X |X |-- |-- |--  
 |comp-tend |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- 
+|exp-int-rail |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- |-- 
 |===
 
 
@@ -2720,12 +2723,13 @@ code; A: allowed code and procedure may additionally be accelerated) :
 |open |-- |-- |-- |-- |-- 
 |restricted |-- |-- |-- |-- |-- 
 |neg-w-call |-- |-- |-- |-- |-- 
-|neg-wo-call |-- |-- |-- |-- |-- 
+|neg-wo-call |-- |X |X |-- |-- 
 |comp-dial |-- |-- |-- |-- |-- 
 |innovation |-- |-- |-- |-- |-- 
 |oth-single |-- |-- |-- |-- |-- 
 |oth-mult |-- |-- |-- |-- |-- 
 |comp-tend |-- |X |X |-- |-- 
+|exp-int-rail |-- |X |X |-- |-- 
 |===
 
 


### PR DESCRIPTION
Adding the new Procedure Type "exp-int-rail" and allowing its use and the one of "neg-wo-call" for T01 and T02 Notice Subtypes.
To be applied to documentation 1.11 only as this will not be backported.