### PR TITLE
active-versions: Update extended lifespans dates

### DIFF
--- a/modules/ROOT/pages/active-versions/index.adoc
+++ b/modules/ROOT/pages/active-versions/index.adoc
@@ -57,29 +57,25 @@ IMPORTANT: The table below is updated manually and may not be always accurate. T
 |End of standard lifespan
 |End of extended lifespan
 
-|1.6
-|6 March 2024
-|30 September 2024
-
 |1.7
 |11 May 2024
-|28 February 2025
+|30 April 2025
 
 |1.8
 |26 July 2024
-|28 February 2025
+|30 April 2025
 
 |1.9
 |9 October 2024
-|28 February 2025
+|30 April 2025
 
 |1.10
 |1 December 2024
-|28 February 2025
+|30 April 2025
 
 |1.11
 |22 April 2025
-|22 April 2025
+|30 April 2025
 
 |1.12
 |18 July 2025


### PR DESCRIPTION
Delay end of extended lifespans for SDK 1.11 and earlier to 30/04/2025.

Also remove line for SDK 1.6, as its extended lifespan ended some time ago.