### PR TITLE
TEDEMD-611 - added escape character \ to fix table cell splitting

### DIFF
--- a/modules/reference/pages/business-rules/index.adoc
+++ b/modules/reference/pages/business-rules/index.adoc
@@ -9115,7 +9115,7 @@ a|Co_constraint.
 .Co-constraint in EFX
 [source, EFX]
 ----
-BT-500-Organization-Company[BT-500-Organization-Company/@languageID is not empty] not like '.*(T|t)(E|e)(S|s)(T|t).*'
+BT-500-Organization-Company[BT-500-Organization-Company/@languageID is not empty] not like '.*(T\|t)(E\|e)(S\|s)(T\|t).*'
 ----
 *Always applies* in every notice sub-type.
 |`WARN`


### PR DESCRIPTION
I fixed the index.adoc, but the expression that caused the issue is also found in attachments/business-rules.csv. I don't know how the generation works, so I didn't change that.